### PR TITLE
fix: link cursor

### DIFF
--- a/d2l-navigation-link.js
+++ b/d2l-navigation-link.js
@@ -14,6 +14,7 @@ class D2LNavigationLink extends mixinBehaviors([D2L.PolymerBehaviors.FocusableBe
 	static get properties() {
 		return {
 			href: {
+				reflectToAttribute: true,
 				type: String
 			},
 			text: {


### PR DESCRIPTION
This is a regression from #134. In the link behavior that was removed, [it was setting](https://github.com/BrightspaceUI/link/blob/master/d2l-link-behavior.js#L25) `reflectToAttribute: true` on the `href` attribute. That was lost... which normally probably wouldn't matter, except that `d2l-navigation-link` has this CSS:

```css
:host(:not([href])) a {
  cursor: default;
}
```

So if the host doesn't have an `href`, the cursor is reset on the `<a>`. Not sure why that's there and why it wouldn't just _not_ have an `<a>` if there's no `href`, but probably the answer is "Polymer".

This defect didn't escape into the June release, so just July.