### PR TITLE
Lit conversion of d2l-navigation-link-image

### DIFF
--- a/d2l-navigation-link-image.js
+++ b/d2l-navigation-link-image.js
@@ -1,62 +1,63 @@
-import './d2l-navigation-link.js';
+import { css, html, LitElement } from 'lit';
+import { FocusMixin } from '@brightspace-ui/core/mixins/focus-mixin.js';
+import { highlightBorderStyles, highlightLinkStyles } from './d2l-navigation-styles.js';
 
-import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
-/**
-`d2l-navigation-link-image`
-Polymer-based web component for the image link used in the navigational header.
-
-@demo demo/d2l-navigation-button.html d2l-navigation-link-image
-*/
-class D2LNavigationLinkImage extends PolymerElement {
+class NavigationLinkImage extends FocusMixin(LitElement) {
 
 	static get properties() {
 		return {
-			src: {
-				type: String
-			},
-			href: {
-				type: String
-			},
-			slim: {
-				reflectToAttribute: true,
-				type: Boolean,
-				value: false
-			},
-			text: {
-				type: String,
-				value: ''
-			}
+			href: { type: String },
+			slim: { reflect: true, type: Boolean },
+			src: { type: String },
+			text: { type: String }
 		};
 	}
-	static get template() {
-		const template = html`
-			<style>
+
+	static get styles() {
+		return [highlightBorderStyles, highlightLinkStyles, css`
 			:host {
 				display: inline-block;
 				height: 100%;
 			}
+			:host([hidden]) {
+				display: none;
+			}
 			img {
-				vertical-align: middle;
-				border: none; /* needed for IE10 */
 				max-height: 60px;
 				max-width: 260px;
+				vertical-align: middle;
 			}
 			:host([slim]) img {
 				max-height: 40px;
 				max-width: 173px;
 			}
 			.d2l-navigation-link-image-container {
-				height: 100%;
-				vertical-align: middle;
 				align-items: center;
 				display: inline-flex;
+				height: 100%;
+				vertical-align: middle;
 			}
-		</style>
-		<d2l-navigation-link href="[[href]]" text="[[text]]">
-			<span class="d2l-navigation-link-image-container"><img src="[[src]]" alt$="[[text]]"></span>
-		</d2l-navigation-link>`;
-		template.setAttribute('strip-whitespace', '');
-		return template;
+		`];
+	}
+
+	constructor() {
+		super();
+		this.slim = false;
+		this.text = '';
+	}
+
+	static get focusElementSelector() {
+		return 'a';
+	}
+
+	render() {
+		return html`
+			<a href="${this.href}" title="${this.text}">
+				<span class="d2l-navigation-highlight-border"></span>
+				<span class="d2l-navigation-link-image-container"><img src="${this.src}" alt="${this.text}"></span>
+			</a>
+		`;
 	}
 }
-customElements.define('d2l-navigation-link-image', D2LNavigationLinkImage);
+
+customElements.define('d2l-navigation-link-image', NavigationLinkImage);

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "lint": "npm run lint:eslint && npm run lint:lit && npm run lint:style",
     "lint:eslint": "eslint . --ext .js,.html",
-    "lint:lit": "lit-analyzer d2l-navigation.js d2l-navigation-button-icon.js d2l-navigation-link-back.js d2l-navigation-link-icon.js d2l-navigation-separator.js ./components/d2l-navigation-iterator/d2l-navigation-iterator.js --strict --rules.no-unknown-tag-name off",
+    "lint:lit": "lit-analyzer d2l-navigation.js d2l-navigation-button-icon.js d2l-navigation-link-back.js d2l-navigation-link-icon.js d2l-navigation-link-image.js d2l-navigation-separator.js ./components/d2l-navigation-iterator/d2l-navigation-iterator.js --strict --rules.no-unknown-tag-name off",
     "lint:style": "stylelint \"**/*.{js,html}\"",
     "start": "web-dev-server --node-resolve --watch --open --app-index demo/index.html",
     "test": "npm run lint && npm run test:headless",


### PR DESCRIPTION
Another simple one, this migrates `<d2l-navigation-link-image>` to Lit by leveraging the shared link styles.

Not expecting any visual diffs here. 🤞 