### PR TITLE
fix: don't render anchor if no href

### DIFF
--- a/d2l-navigation-link-image.js
+++ b/d2l-navigation-link-image.js
@@ -51,12 +51,15 @@ class NavigationLinkImage extends FocusMixin(LitElement) {
 	}
 
 	render() {
-		return html`
-			<a href="${this.href}" title="${this.text}">
-				<span class="d2l-navigation-highlight-border"></span>
-				<span class="d2l-navigation-link-image-container"><img src="${this.src}" alt="${this.text}"></span>
-			</a>
-		`;
+		if (this.href) {
+			return html`
+				<a href="${this.href}" title="${this.text}">
+					<span class="d2l-navigation-highlight-border"></span>
+					<span class="d2l-navigation-link-image-container"><img src="${this.src}" alt="${this.text}"></span>
+				</a>
+			`;
+		}
+		return html`<span class="d2l-navigation-link-image-container"><img src="${this.src}" alt="${this.text}" title="${this.text}"></span>`;
 	}
 }
 

--- a/demo/button-link.html
+++ b/demo/button-link.html
@@ -69,6 +69,9 @@
 						href="https://www.example.org"
 						src="./logo-image.png"
 						text="Link Image Text"></d2l-navigation-link-image>
+					<d2l-navigation-link-image
+						src="./logo-image.png"
+						text="Link Image Text"></d2l-navigation-link-image>
 				</div>
 			</d2l-demo-snippet>
 

--- a/test/link.test.js
+++ b/test/link.test.js
@@ -86,10 +86,17 @@ describe('Links', () => {
 	describe('d2l-navigation-link-image', () => {
 
 		describe('accessibility', () => {
-			it('should pass all aXe tests', async() => {
+
+			it('default', async() => {
 				const el = await fixture(html`<d2l-navigation-link-image src="../demo/logo-image.png" href="https:/www.d2l.com" text="D2L"></d2l-navigation-link-image>`);
 				await expect(el).to.be.accessible();
 			});
+
+			it('no href', async() => {
+				const el = await fixture(html`<d2l-navigation-link-image src="../demo/logo-image.png" text="D2L"></d2l-navigation-link-image>`);
+				await expect(el).to.be.accessible();
+			});
+
 		});
 
 		describe('constructor', () => {

--- a/test/link.visual-diff.html
+++ b/test/link.visual-diff.html
@@ -36,5 +36,8 @@
 		<div class="visual-diff">
 			<d2l-navigation-link-image id="image" src="../demo/logo-image.png" href="https:/www.d2l.com" text="D2L"></d2l-navigation-link-image>
 		</div>
+		<div class="visual-diff">
+			<d2l-navigation-link-image id="image-no-href" src="../demo/logo-image.png" text="D2L"></d2l-navigation-link-image>
+		</div>
 	</body>
 </html>

--- a/test/link.visual-diff.js
+++ b/test/link.visual-diff.js
@@ -29,7 +29,8 @@ describe('d2l-navigation-link', () => {
 		{ category: 'back', tests: ['normal', 'hover', 'focus'] },
 		{ category: 'icon-text', tests: ['normal', 'hover', 'focus'] },
 		{ category: 'icon-text-hidden', rectSelector: 'icon-text-hidden-container', tests: ['normal', 'hover', 'focus'] },
-		{ category: 'image', tests: ['normal', 'hover', 'focus'] }
+		{ category: 'image', tests: ['normal', 'hover', 'focus'] },
+		{ category: 'image-no-href', tests: ['normal', 'hover'] }
 	].forEach((entry) => {
 		describe(entry.category, () => {
 			entry.tests.forEach((name) => {


### PR DESCRIPTION
Small fix to `<d2l-navigation-link-image>`. The LMS is using this component to render the logo, but the user can choose for there to be no link.

<img width="368" alt="Screen Shot 2022-07-12 at 10 42 08 AM" src="https://user-images.githubusercontent.com/5491151/178518018-01f4390c-af1f-4c8c-b90b-e10fe633617e.png">

Previously `<d2l-navigation-link>` was still rendering an `<a>` but because the `href` wasn't set, the "highlight border" wasn't showing up. I've adjusted `<d2l-navigation-link-image>` to conditionally render the `<a>` which seems like a better outcome.