### PR TITLE
fix: set type for button

### DIFF
--- a/d2l-navigation-button-icon.js
+++ b/d2l-navigation-button-icon.js
@@ -105,7 +105,7 @@ class NavigationButtonIcon extends FocusMixin(LitElement) {
 		const highlightBorder = !this.disabled ? html`<span class="d2l-navigation-highlight-border"></span>` : nothing;
 		const icon = html`<d2l-icon icon="${this.icon}"></d2l-icon>`;
 		return html`
-			<button id="${ifDefined(id)}" ?disabled="${this.disabled}" aria-label="${ifDefined(ariaLabel)}">
+			<button id="${ifDefined(id)}" ?disabled="${this.disabled}" aria-label="${ifDefined(ariaLabel)}" type="button">
 				${highlightBorder}
 				${this.iconPosition === 'start' ? icon : nothing}
 				${text}


### PR DESCRIPTION
Forgot that for some silly reason, `<button>`'s `type` defaults to `submit`, which means pressing ENTER on this button would submit any forms that were on the page. We want these to be standard `button` types.