### PR TITLE
fix: close tooltips when buttons are clicked

### DIFF
--- a/d2l-navigation-button-icon.js
+++ b/d2l-navigation-button-icon.js
@@ -121,7 +121,7 @@ class NavigationButtonIcon extends FocusMixin(LitElement) {
 				ariaLabel: this.text,
 				id: this._buttonId,
 				text: nothing,
-				tooltip: html`<d2l-tooltip for="${this._buttonId}" for-type="label">${this.text}</d2l-tooltip>`
+				tooltip: html`<d2l-tooltip for="${this._buttonId}" for-type="label" close-on-click>${this.text}</d2l-tooltip>`
 			};
 		}
 		return {


### PR DESCRIPTION
Small fix that I think we want everywhere, but it also resolves this crazy issue in sequences:

![tooltip-before](https://user-images.githubusercontent.com/5491151/178789961-68f23c05-3d78-48c3-bae0-15c9cea6f7e9.gif)

The issue there is that the target for the tooltip actually moves when the sidebar opens, and tooltip really has no mechanism to know that this happened and reposition itself. `ResizeObserver` and `MutationObserver` don't fire when things move, only when they change size or mutate. Either way, I still think just hiding the tooltip on-click is a nicer experience anyway.

After:
![tooltip-after](https://user-images.githubusercontent.com/5491151/178790150-669378d7-085b-4aa3-85f0-c162e17dcbae.gif)

