### PR TITLE
fix: tooltip position

### DIFF
--- a/d2l-navigation-link-icon.js
+++ b/d2l-navigation-link-icon.js
@@ -84,7 +84,7 @@ class NavigationLinkIcon extends FocusMixin(LitElement) {
 				ariaLabel: this.text,
 				id: this._linkId,
 				text: nothing,
-				tooltip: html`<d2l-tooltip for="${this._linkId}" for-type="label">${this.text}</d2l-tooltip>`
+				tooltip: html`<d2l-tooltip for="${this._linkId}" for-type="label" position="bottom">${this.text}</d2l-tooltip>`
 			};
 		}
 		return {


### PR DESCRIPTION
Missed this one compared to the others -- we always want these opening down otherwise they open to the right on cover over other things in the nav.