### PR TITLE
fix: go back to the host being the flex container

### DIFF
--- a/components/d2l-navigation-iterator/d2l-navigation-iterator.js
+++ b/components/d2l-navigation-iterator/d2l-navigation-iterator.js
@@ -17,13 +17,16 @@ class NavigationIterator extends  LocalizeNavigationElement(LitElement) {
 
 	static get styles() {
 		return [bodyCompactStyles, css`
-			.wrapper {
+			:host {
 				align-items: center;
 				display: flex;
 				height: 3.3rem;
 				justify-content: space-between;
 				max-width: 20rem;
 				padding: 0 1.2rem;
+			}
+			:host([hidden]) {
+				display: none;
 			}
 		`];
 	}
@@ -41,23 +44,23 @@ class NavigationIterator extends  LocalizeNavigationElement(LitElement) {
 		const previousText = this.previousText ? this.previousText : this.localize('previous');
 		const nextText = this.nextText ? this.nextText : this.localize('next');
 		return html`
-			<div class="wrapper d2l-body-compact">
-				<d2l-navigation-button-icon
-					icon="tier3:chevron-left-circle"
-					icon-position="start"
-					text="${previousText}"
-					?text-hidden="${this.hideText}"
-					?disabled="${this.previousDisabled}"
-					@click="${this._dispatchPreviousClicked}"></d2l-navigation-button-icon>
-				<slot></slot>
-				<d2l-navigation-button-icon
-					icon="tier3:chevron-right-circle"
-					icon-position="end"
-					text="${nextText}"
-					?text-hidden="${this.hideText}"
-					?disabled="${this.nextDisabled}"
-					@click="${this._dispatchNextClicked}"></d2l-navigation-button-icon>
-			</div>
+			<d2l-navigation-button-icon
+				class="d2l-body-compact"
+				icon="tier3:chevron-left-circle"
+				icon-position="start"
+				text="${previousText}"
+				?text-hidden="${this.hideText}"
+				?disabled="${this.previousDisabled}"
+				@click="${this._dispatchPreviousClicked}"></d2l-navigation-button-icon>
+			<slot class="d2l-body-compact"></slot>
+			<d2l-navigation-button-icon
+				class="d2l-body-compact"
+				icon="tier3:chevron-right-circle"
+				icon-position="end"
+				text="${nextText}"
+				?text-hidden="${this.hideText}"
+				?disabled="${this.nextDisabled}"
+				@click="${this._dispatchNextClicked}"></d2l-navigation-button-icon>
 		`;
 	}
 


### PR DESCRIPTION
Cert version of this fix: https://github.com/BrightspaceUILabs/navigation/pull/171

In the [pre-Lit Polymer version](https://github.com/BrightspaceUILabs/navigation/blob/d4ca49dec78b0d4b2c7fcfdd0b06cf6332267cad/components/d2l-navigation-iterator/d2l-navigation-iterator.js#L39) of this component, the `flex` was applied to the host. But because it was also apply a Polymer style mixin that I couldn't use in Lit, I moved all of that CSS to a container where I could apply "compact text" styles.

Unfortunately, there was [code in the LMS](https://search.d2l.dev/xref/lms/lp/framework/web/D2L.LP.Web.UI/Desktop/Controls/ImmersiveNav/ImmersiveNav.css?r=0136e0e3#32) applying some negative margins that did some funky stuff to the non-flex element:

<img width="306" alt="Screen Shot 2022-07-22 at 3 06 20 PM" src="https://user-images.githubusercontent.com/5491151/180506908-33c39d3e-ad37-473e-ab1b-7059ca9b49e5.png">

So I'm reverting back to applying the flex to the host, removing the wrapper and then applying "compact text" styles to the buttons and the slot. I'm also making a [small change to how the LMS styles this](https://github.com/Brightspace/lms/pull/25671) in order to simply cancel out the built-in padding of the component, instead of using weird negative margins to reverse it.

~This should result in a very small visual diff to just the version that has stuff inside the slot, the end result of which is a 1px improvement in the vertical alignment.~ Apparently not.