### PR TITLE
Remove bad import of d2l-navigation-shared-styles

### DIFF
--- a/d2l-navigation-band.js
+++ b/d2l-navigation-band.js
@@ -1,8 +1,7 @@
 import '@brightspace-ui/core/components/colors/colors.js';
-import './d2l-navigation-shared-styles';
-
 import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
-import { navigationSharedStyle } from './d2l-navigation-shared-styles';
+import { navigationSharedStyle } from './d2l-navigation-shared-styles.js';
+
 /**
 `d2l-navigation-band`
 Polymer-based web component for a solid colour band that runs along the top of the navigational header


### PR DESCRIPTION
Removing import of d2l-navigation-shared-styles that was causing issues with webpack in folio.