### PR TITLE
Fix d2l-navigation-iterator import

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@
 
 A series of web components for top level navigation use in D2L applications.
 
+## Installation
+
+```shell
+npm install @brightspace-ui-labs/navigation
+```
+
 ![screenshot of sample usage](/screenshots/navigation.png?raw=true)
 
 ## Usage: Primary Components
@@ -188,7 +194,7 @@ Similar to `<d2l-navigation-button-icon>`, a link that comes with an icon and op
 
 ```html
 <script type="module">
-  import '@brightspace-ui-labs/navigation/d2l-navigation-iterator.js';
+  import '@brightspace-ui-labs/navigation/components/d2l-navigation-iterator/d2l-navigation-iterator.js';
 </script>
 
 <d2l-navigation-iterator></d2l-navigation-iterator>


### PR DESCRIPTION
I've added how to `npm install` this repo since it was missing and also corrected the import for the `d2l-navigation-iterator` component.