### PR TITLE
feat: Add tooltipOffset

### DIFF
--- a/d2l-navigation-button-icon.js
+++ b/d2l-navigation-button-icon.js
@@ -43,7 +43,12 @@ class NavigationButtonIcon extends FocusMixin(LitElement) {
 			 * Visually hides the text but still accessible
 			 * @type {boolean}
 			 */
-			textHidden: { attribute: 'text-hidden', type: Boolean }
+			textHidden: { attribute: 'text-hidden', type: Boolean },
+			/**
+			 * Offset of the tooltip
+			 * @type {Number}
+			 */
+			tooltipOffset: { attribute: 'tooltip-offset', type: Number }
 		};
 	}
 
@@ -93,7 +98,7 @@ class NavigationButtonIcon extends FocusMixin(LitElement) {
 				ariaLabel: this.text,
 				id: this._buttonId,
 				text: nothing,
-				tooltip: html`<d2l-tooltip close-on-click for="${this._buttonId}" for-type="label" position="bottom">${this.text}</d2l-tooltip>`
+				tooltip: html`<d2l-tooltip close-on-click for="${this._buttonId}" for-type="label" position="bottom" offset="${ifDefined(this.tooltipOffset)}">${this.text}</d2l-tooltip>`
 			};
 		}
 		return {

--- a/d2l-navigation-dropdown-button-icon.js
+++ b/d2l-navigation-dropdown-button-icon.js
@@ -15,7 +15,8 @@ class NavigationDropdownButtonIcon extends DropdownOpenerMixin(LitElement) {
 			icon: { type: String },
 			hasNotification: { attribute: 'has-notification', reflect: true, type: Boolean },
 			text: { type: String },
-			notificationText: { attribute: 'notification-text', type: String }
+			notificationText: { attribute: 'notification-text', type: String },
+			tooltipOffset: { attribute: 'tooltip-offset', type: Number }
 		};
 	}
 
@@ -50,7 +51,7 @@ class NavigationDropdownButtonIcon extends DropdownOpenerMixin(LitElement) {
 	render() {
 		const { ariaDescribedBy, ariaDescription, contents } = this._getRenderSettings();
 		const highlightBorder = !this.disabled ? html`<span class="d2l-navigation-highlight-border"></span>` : nothing;
-		const tooltip = !this.dropdownOpened ? html`<d2l-tooltip close-on-click for="${this._buttonId}" for-type="label" position="bottom">${this.text}</d2l-tooltip>` : nothing;
+		const tooltip = !this.dropdownOpened ? html`<d2l-tooltip close-on-click for="${this._buttonId}" for-type="label" position="bottom" offset="${ifDefined(this.tooltipOffset)}">${this.text}</d2l-tooltip>` : nothing;
 		return html`
 			<button
 				aria-describedby="${ifDefined(ariaDescribedBy)}"

--- a/d2l-navigation-link-icon.js
+++ b/d2l-navigation-link-icon.js
@@ -33,7 +33,12 @@ class NavigationLinkIcon extends FocusMixin(LitElement) {
 			 * Visually hides the text but still accessible
 			 * @type {boolean}
 			 */
-			textHidden: { attribute: 'text-hidden', type: Boolean }
+			textHidden: { attribute: 'text-hidden', type: Boolean },
+			/**
+			 * Offset of the tooltip
+			 * @type {Number}
+			 */
+			tooltipOffset: { attribute: 'tooltip-offset', type: Number }
 		};
 	}
 
@@ -92,7 +97,7 @@ class NavigationLinkIcon extends FocusMixin(LitElement) {
 				ariaLabel: this.text,
 				id: this._linkId,
 				text: nothing,
-				tooltip: html`<d2l-tooltip for="${this._linkId}" for-type="label" position="bottom">${this.text}</d2l-tooltip>`
+				tooltip: html`<d2l-tooltip for="${this._linkId}" for-type="label" position="bottom" offset="${ifDefined(this.tooltipOffset)}">${this.text}</d2l-tooltip>`
 			};
 		}
 		return {

--- a/d2l-navigation-link-image.js
+++ b/d2l-navigation-link-image.js
@@ -2,6 +2,7 @@ import '@brightspace-ui/core/components/tooltip/tooltip.js';
 import { css, html, LitElement } from 'lit';
 import { FocusMixin } from '@brightspace-ui/core/mixins/focus-mixin.js';
 import { getUniqueId } from '@brightspace-ui/core/helpers/uniqueId.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
 import { highlightBorderStyles, highlightLinkStyles } from './d2l-navigation-styles.js';
 
 class NavigationLinkImage extends FocusMixin(LitElement) {
@@ -11,7 +12,8 @@ class NavigationLinkImage extends FocusMixin(LitElement) {
 			href: { type: String },
 			slim: { reflect: true, type: Boolean },
 			src: { type: String },
-			text: { type: String }
+			text: { type: String },
+			tooltipOffset: { attribute: 'tooltip-offset', type: Number }
 		};
 	}
 
@@ -60,7 +62,7 @@ class NavigationLinkImage extends FocusMixin(LitElement) {
 					<span class="d2l-navigation-highlight-border"></span>
 					<span class="d2l-navigation-link-image-container"><img src="${this.src}" alt="${this.text}"></span>
 				</a>
-				<d2l-tooltip for="${this._linkId}" for-type="label" position="bottom">${this.text}</d2l-tooltip>
+				<d2l-tooltip for="${this._linkId}" for-type="label" position="bottom" offset="${ifDefined(this.tooltipOffset)}">${this.text}</d2l-tooltip>
 			`;
 		}
 		return html`<span class="d2l-navigation-link-image-container"><img src="${this.src}" alt="${this.text}"></span>`;


### PR DESCRIPTION
Adding `tooltip-offset` attribute to all components that internally use `<d2l-tooltip>`. The goal is to set this offset to 0 for navigation items on the main page of the LMS, per the [design specs](https://www.figma.com/proto/jxxWTG3fC0nNPgvECXcZ0D/Tooltips---Improved-Contrast?page-id=0%3A1&node-id=2%3A48&viewport=-875%2C658%2C0.39&scaling=min-zoom&starting-point-node-id=2%3A48).

Rally: https://rally1.rallydev.com/#/?detail=/defect/645635571497&fdp=true