### PR TITLE
DE50035 - For d2l-navigation-link-image, hide the tooltip if it's empty

### DIFF
--- a/d2l-navigation-link-image.js
+++ b/d2l-navigation-link-image.js
@@ -1,5 +1,5 @@
 import '@brightspace-ui/core/components/tooltip/tooltip.js';
-import { css, html, LitElement } from 'lit';
+import { css, html, LitElement, nothing } from 'lit';
 import { FocusMixin } from '@brightspace-ui/core/mixins/focus-mixin.js';
 import { getUniqueId } from '@brightspace-ui/core/helpers/uniqueId.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
@@ -62,7 +62,7 @@ class NavigationLinkImage extends FocusMixin(LitElement) {
 					<span class="d2l-navigation-highlight-border"></span>
 					<span class="d2l-navigation-link-image-container"><img src="${this.src}" alt="${this.text}"></span>
 				</a>
-				<d2l-tooltip for="${this._linkId}" for-type="label" position="bottom" offset="${ifDefined(this.tooltipOffset)}">${this.text}</d2l-tooltip>
+				${this.text ? html`<d2l-tooltip for="${this._linkId}" for-type="label" position="bottom" offset="${ifDefined(this.tooltipOffset)}">${this.text}</d2l-tooltip>` : nothing}
 			`;
 		}
 		return html`<span class="d2l-navigation-link-image-container"><img src="${this.src}" alt="${this.text}"></span>`;


### PR DESCRIPTION
Because the LMS doesn't currently require alt text for a custom link destination for the logo, some clients might have started seeing a blank tooltip.  This PR only renders the tooltip if there is text.

I'm only adding this to the one component that needs it because `text` is required and the navigation web components aren't expecting not to get it.  The blank tooltip makes it easier for developers to see they've forgotten the `text`, so we're leaving it in the other components.  I'll investigate separately making the alt text required in the LMS field going forward.