### PR TITLE
Update d2l-demo-snippet fullscreen to full-width

### DIFF
--- a/demo/navigation.html
+++ b/demo/navigation.html
@@ -40,7 +40,7 @@
 	<body>
 		<d2l-demo-page page-title="d2l-navigation">
 			<h2>Header and Footer</h2>
-			<d2l-demo-snippet fullscreen>
+			<d2l-demo-snippet full-width>
 				<d2l-navigation has-skip-nav>
 					<d2l-navigation-main-header>
 						<div slot="left" class="d2l-navigation-header-left">This should be on the left.  As the width changes it shrinks as needed.</div>
@@ -53,7 +53,7 @@
 			</d2l-demo-snippet>
 
 			<h2>Just Header</h2>
-			<d2l-demo-snippet fullscreen>
+			<d2l-demo-snippet full-width>
 				<d2l-navigation>
 					<d2l-navigation-main-header>
 						<div slot="left" class="d2l-navigation-header-left">This should be on the left.  As the width changes it shrinks as needed.</div>
@@ -68,12 +68,12 @@
 			</d2l-demo-snippet>
 
 			<h2>Band Default</h2>
-			<d2l-demo-snippet fullscreen>
+			<d2l-demo-snippet full-width>
 				<d2l-navigation-band></d2l-navigation-band>
 			</d2l-demo-snippet>
 
 			<h2>Band Content Slotted</h2>
-			<d2l-demo-snippet fullscreen>
+			<d2l-demo-snippet full-width>
 				<d2l-navigation>
 					<div slot="navigation-band">
 						<button>consortium 1</button>
@@ -89,7 +89,7 @@
 			</d2l-demo-snippet>
 
 			<h2>Band Content Slotted Scrollbar</h2>
-			<d2l-demo-snippet fullscreen overflow-hidden>
+			<d2l-demo-snippet full-width overflow-hidden>
 				<d2l-navigation>
 					<div slot="navigation-band">
 						<button class="scrollable">consortium 1</button>


### PR DESCRIPTION
The `d2l-demo-snippet` attribute `fullscreen` is being renamed to full-width. These changes will need to happen more or less at the same time as core is updated.

Once the changes are released in `core` this PR will be updated to bump the dependency version.

BrightspaceUI/core#2926

[US144714](https://rally1.rallydev.com/#/?detail=/userstory/665191647783&fdp=true): Add fullscreen switch to d2l-demo-snippet
