### PR TITLE
DE51509 - add tooltip-position property to d2l-navigation-button-icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Add the `d2l-navigation-main-footer` component, and provide elements for the `ma
 | `icon` | String | Preset icon key (e.g. `tier1:gear`) |
 | `no-highlight-border` | Boolean | Visually hides the highlight border when hovered/focused |
 | `text-hidden` | Boolean | Visually hides the text |
-| `tooltip-location` | String | Location of the tooltip ( top\|bottom\|left\|right ); default is bottom |
+| `tooltip-position` | String | Position of the tooltip ( top\|bottom\|left\|right ); default is bottom |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ Add the `d2l-navigation-main-footer` component, and provide elements for the `ma
 | `icon` | String | Preset icon key (e.g. `tier1:gear`) |
 | `no-highlight-border` | Boolean | Visually hides the highlight border when hovered/focused |
 | `text-hidden` | Boolean | Visually hides the text |
+| `tooltip-location` | String | Location of the tooltip ( top\|bottom\|left\|right ); default is bottom |
 
 ---
 

--- a/d2l-navigation-button-icon.js
+++ b/d2l-navigation-button-icon.js
@@ -45,15 +45,15 @@ class NavigationButtonIcon extends FocusMixin(LitElement) {
 			 */
 			textHidden: { attribute: 'text-hidden', type: Boolean },
 			/**
-			 * Location of the tooltip
-			 * @type {'top'|'bottom'|'left'|'right'}
-			 */
-			tooltipLocation: { attribute: 'tooltip-location', type: String },
-			/**
 			 * Offset of the tooltip
 			 * @type {Number}
 			 */
-			tooltipOffset: { attribute: 'tooltip-offset', type: Number }
+			tooltipOffset: { attribute: 'tooltip-offset', type: Number },
+			/**
+			 * Position of the tooltip
+			 * @type {'top'|'bottom'|'left'|'right'}
+			 */
+			tooltipPosition: { attribute: 'tooltip-position', type: String }
 		};
 	}
 
@@ -76,7 +76,7 @@ class NavigationButtonIcon extends FocusMixin(LitElement) {
 		this.noHighlightBorder = false;
 		this.textHidden = false;
 		this._buttonId = getUniqueId();
-		this.tooltipLocation = 'bottom';
+		this.tooltipPosition = 'bottom';
 	}
 
 	static get focusElementSelector() {
@@ -104,7 +104,7 @@ class NavigationButtonIcon extends FocusMixin(LitElement) {
 				ariaLabel: this.text,
 				id: this._buttonId,
 				text: nothing,
-				tooltip: html`<d2l-tooltip close-on-click for="${this._buttonId}" for-type="label" position="${this.tooltipLocation}" offset="${ifDefined(this.tooltipOffset)}">${this.text}</d2l-tooltip>`
+				tooltip: html`<d2l-tooltip close-on-click for="${this._buttonId}" for-type="label" position="${this.tooltipPosition}" offset="${ifDefined(this.tooltipOffset)}">${this.text}</d2l-tooltip>`
 			};
 		}
 		return {

--- a/d2l-navigation-button-icon.js
+++ b/d2l-navigation-button-icon.js
@@ -45,6 +45,11 @@ class NavigationButtonIcon extends FocusMixin(LitElement) {
 			 */
 			textHidden: { attribute: 'text-hidden', type: Boolean },
 			/**
+			 * Location of the tooltip
+			 * @type {'top'|'bottom'|'left'|'right'}
+			 */
+			tooltipLocation: { attribute: 'tooltip-location', type: String },
+			/**
 			 * Offset of the tooltip
 			 * @type {Number}
 			 */
@@ -71,6 +76,7 @@ class NavigationButtonIcon extends FocusMixin(LitElement) {
 		this.noHighlightBorder = false;
 		this.textHidden = false;
 		this._buttonId = getUniqueId();
+		this.tooltipLocation = 'bottom';
 	}
 
 	static get focusElementSelector() {
@@ -98,7 +104,7 @@ class NavigationButtonIcon extends FocusMixin(LitElement) {
 				ariaLabel: this.text,
 				id: this._buttonId,
 				text: nothing,
-				tooltip: html`<d2l-tooltip close-on-click for="${this._buttonId}" for-type="label" position="bottom" offset="${ifDefined(this.tooltipOffset)}">${this.text}</d2l-tooltip>`
+				tooltip: html`<d2l-tooltip close-on-click for="${this._buttonId}" for-type="label" position="${this.tooltipLocation}" offset="${ifDefined(this.tooltipOffset)}">${this.text}</d2l-tooltip>`
 			};
 		}
 		return {


### PR DESCRIPTION
[DE51509](https://rally1.rallydev.com/#/42960320374ud/custom/236803223728?detail=%2Fdefect%2F675164753105): Tool tip for iterating between students in CE is cut off

Pairs with this PR:
* https://github.com/Brightspace/consistent-evaluation/pull/1631

![image](https://github.com/BrightspaceUILabs/navigation/assets/126340096/381079c2-c589-4e79-a1c6-2f11b017df4d)
