### PR TITLE
Remove constructor-test-helper reference

### DIFF
--- a/test/button.test.js
+++ b/test/button.test.js
@@ -3,9 +3,8 @@ import '../d2l-navigation-button-icon.js';
 import '../d2l-navigation-dropdown-button-custom.js';
 import '../d2l-navigation-dropdown-button-icon.js';
 import '../d2l-navigation-notification-icon.js';
-import { expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
+import { expect, fixture, html, oneEvent, runConstructor } from '@brightspace-ui/testing';
 import { getComposedActiveElement } from '@brightspace-ui/core/helpers/focus.js';
-import { runConstructor } from '@brightspace-ui/core/tools/constructor-test-helper.js';
 
 describe('Buttons', () => {
 

--- a/test/immersive.test.js
+++ b/test/immersive.test.js
@@ -1,6 +1,5 @@
 import '../d2l-navigation-immersive.js';
-import { expect, fixture, html } from '@brightspace-ui/testing';
-import { runConstructor } from '@brightspace-ui/core/tools/constructor-test-helper.js';
+import { expect, fixture, html, runConstructor } from '@brightspace-ui/testing';
 
 describe('d2l-navigation-immersive', () => {
 

--- a/test/iterator.test.js
+++ b/test/iterator.test.js
@@ -1,6 +1,5 @@
 import '../components/d2l-navigation-iterator/d2l-navigation-iterator.js';
-import { expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
-import { runConstructor } from '@brightspace-ui/core/tools/constructor-test-helper.js';
+import { expect, fixture, html, oneEvent, runConstructor } from '@brightspace-ui/testing';
 
 describe('d2l-navigation-iterator', () => {
 

--- a/test/link.test.js
+++ b/test/link.test.js
@@ -2,9 +2,8 @@ import '../d2l-navigation-link.js';
 import '../d2l-navigation-link-back.js';
 import '../d2l-navigation-link-icon.js';
 import '../d2l-navigation-link-image.js';
-import { expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
+import { expect, fixture, html, oneEvent, runConstructor } from '@brightspace-ui/testing';
 import { getComposedActiveElement } from '@brightspace-ui/core/helpers/focus.js';
-import { runConstructor } from '@brightspace-ui/core/tools/constructor-test-helper.js';
 
 describe('Links', () => {
 

--- a/test/navigation.test.js
+++ b/test/navigation.test.js
@@ -3,8 +3,7 @@ import '../d2l-navigation-band.js';
 import '../d2l-navigation-main-header.js';
 import '../d2l-navigation-main-footer.js';
 import '../d2l-navigation-separator.js';
-import { expect, fixture, html } from '@brightspace-ui/testing';
-import { runConstructor } from '@brightspace-ui/core/tools/constructor-test-helper.js';
+import { expect, fixture, html, runConstructor } from '@brightspace-ui/testing';
 
 describe('Navigation', () => {
 


### PR DESCRIPTION
Had this on a to do list for a while lol. This repo uses `@brightspace-ui/testing`, so it can just get `runConstructor` from there. Someday, we'll want to remove the one in `core`.