### PR TITLE
remove npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false


### PR DESCRIPTION
Mostly just want to regenerate the vdiffs so I can be confident my Lit migration isn't causing issues.

This isn't needed since the lock file is already excluded in `.gitignore` and is preventing one from being created in the first place.