### PR TITLE
GAUD-6565: add back link click event

### DIFF
--- a/d2l-navigation-immersive.js
+++ b/d2l-navigation-immersive.js
@@ -206,7 +206,7 @@ class NavigationImmersive extends LitElement {
 						<div class="d2l-navigation-immersive-container">
 							<div class="d2l-navigation-immersive-left d2l-body-compact">
 								<slot name="left">
-									<d2l-navigation-link-back text="${backLinkText}" href="${this.backLinkHref}"></d2l-navigation-link-back>
+									<d2l-navigation-link-back text="${backLinkText}" href="${this.backLinkHref}" @click="${this._handleBackClick}"></d2l-navigation-link-back>
 								</slot>
 							</div>
 							<div class="${classMap(middleContainerClasses)}">
@@ -221,6 +221,15 @@ class NavigationImmersive extends LitElement {
 			</div>
 			<div class="d2l-navigation-immersive-spacing"></div>
 		`;
+	}
+
+	_handleBackClick() {
+		this.dispatchEvent(
+			new CustomEvent(
+				'd2l-navigation-immersive-back-click',
+				{ bubbles: false, composed: false }
+			)
+		);
 	}
 
 	_handlePageResize(e) {

--- a/test/immersive.test.js
+++ b/test/immersive.test.js
@@ -1,5 +1,5 @@
 import '../d2l-navigation-immersive.js';
-import { expect, fixture, html, runConstructor } from '@brightspace-ui/testing';
+import { clickElem, expect, fixture, html, oneEvent, runConstructor } from '@brightspace-ui/testing';
 
 describe('d2l-navigation-immersive', () => {
 
@@ -16,6 +16,20 @@ describe('d2l-navigation-immersive', () => {
 		it('should construct', () => {
 			runConstructor('d2l-navigation-immersive');
 		});
+	});
+
+	describe('events', () => {
+
+		it('should fire back-link-click event', async() => {
+			const el = await fixture(html`<d2l-navigation-immersive></d2l-navigation-immersive>`);
+			const backLink = el
+				.shadowRoot.querySelector('d2l-navigation-link-back')
+				.shadowRoot.querySelector('d2l-navigation-link-icon')
+				.shadowRoot.querySelector('a');
+			clickElem(backLink);
+			await oneEvent(el, 'd2l-navigation-immersive-back-click');
+		});
+
 	});
 
 });


### PR DESCRIPTION
Two of the Insights usages ([example](https://github.com/Brightspace/insights-adoption-dashboard/blob/a5904fc9881fbc12bb65f97bbe1c1a8863afe2cb/insights-adoption-dashboard.js#L142)) are wiring up to a click event handler on the back link to apply some extra logic. This adds an event for them to do that.